### PR TITLE
Improve parser to handle multiple messages in one TCP packet

### DIFF
--- a/src/helpers/Functions.php
+++ b/src/helpers/Functions.php
@@ -31,7 +31,7 @@ class Functions
         }
     }
 
-    public static function isFooterMissing($subject)
+    public static function isOnlyFooterIsMissing($subject)
     {
         if ((static::isHeaderMatch($subject)) && !static::isFooterMatch($subject)) {
             return true;


### PR DESCRIPTION
This PR is related to #2 

It is supposed to fix the parser which is not currently designed for handling multiple `<message>...</message>` patterns in the same TCP packet. 

The proposed solution is to split the packet into array of messages:
https://github.com/baudev/Firebase-Cloud-Messaging-FCM-XMPP/blob/3c339b50f88ca5cb59a5eab6268359ba2c78754e/src/Core.php#L191