### PR TITLE
Accept empty packets when exploding stream data into an array

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -186,9 +186,8 @@ abstract class Core implements FCMListeners
             stream_set_timeout($this->getRemote(), 150);
             // we set an infinite loop
             while (($packetData = $this->read($this->getRemote())) !== 1) {
-
                 // we explode the packet after each footer node
-                $packetArray = preg_split('/(?<=<\/message>)/', $packetData, -1, PREG_SPLIT_NO_EMPTY);
+                $packetArray = preg_split('/(?<=<\/message>)/', $packetData, -1);
                 foreach ($packetArray as $packet) {
                     // make sure that the XML received is well formatted
                     $validXML = $this->analyzeData($packet);


### PR DESCRIPTION
When exploding stream data into an array, the `PREG_SPLIT_NO_EMPTY` was deleting empty packets.
Consequently, the `Keep Alive` response was never sent:
https://github.com/baudev/Firebase-Cloud-Messaging-FCM-XMPP/blob/3c203e8ae8cd7ef3f7eb81f32187258db1e5ee3e/src/Core.php#L329-L332

This bug was introduced by #3 and was reported in #5.